### PR TITLE
Version check bug fixed.

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -9,7 +9,7 @@ repository 'https://github.com/VORPCORE/vorp_traffic'
 client_script 'traffic.lua'
 
 --dont touch
-version '1.0'
+version '1.1'
 vorp_checker 'yes'
 vorp_name '^4Resource version Check^3'
 vorp_github 'https://github.com/VORPCORE/vorp_traffic'


### PR DESCRIPTION
You always get the outdated print because the “version” file contains a different version.